### PR TITLE
Add compose-based env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To get started, you need to prepare a Notion database that is accessible program
 
 ### Choose your setup path:
 *   For local development (if you want to continue the development and make changes), see [LOCAL_DEVELOPMENT.md](./docs/LOCAL_DEVELOPMENT.md)
-*   To use Docker Compose for development, run `docker compose up` after creating `.env` and `.dev.vars`
+*   To use Docker Compose for development, run `docker compose up`. Provide `NOTION_API_KEY` and `NOTION_DATABASE_ID` either in `.env`/`.dev.vars` or directly in `docker-compose.yml`.
 *   For deployment (if you just want this to work), see [DEPLOYMENT.md](./docs/DEPLOYMENT.md)
 
 ## iOS Shortcut and Raycast Integrations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,9 @@ services:
     env_file:
       - .env
       - .dev.vars
+    environment:
+      # Environment variables can also be set here or via an external .env file
+      NOTION_API_KEY: ${NOTION_API_KEY}
+      NOTION_DATABASE_ID: ${NOTION_DATABASE_ID}
     ports:
       - "5173:5173"

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -39,7 +39,7 @@
 
 ### Using Docker Compose
 
-1. Ensure `.env` and `.dev.vars` are present as described above.
+1. Provide the required environment variables (`NOTION_API_KEY` and `NOTION_DATABASE_ID`). You can create `.env` and `.dev.vars` as described above or set them directly in `docker-compose.yml`.
 2. Build and start the container:
 ```bash
 docker compose up --build


### PR DESCRIPTION
## Summary
- allow environment variables to be supplied via `docker-compose.yml`
- document compose environment variable usage in README and Local Development guide
- environment section only lists Notion API key and DB id

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846964b92ec832ea7e8857fa5e3449b